### PR TITLE
webiste/urls.py: Correct 'home' urlpattern

### DIFF
--- a/website/urls.py
+++ b/website/urls.py
@@ -18,7 +18,7 @@ from django.urls import include, path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('home/', include('home.urls')),
+    path('', include('home.urls')),
     path('practice/', include('practice.urls')),
     path('explore/', include('explore.urls')),
     path('leaderboard/', include('leaderboard.urls')),


### PR DESCRIPTION
Since, the website loads by-default on homepage.
So, defining an explicilty suffix to home related
urls can be omitted.

Fixes https://github.com/Utkarsh1308/TabOverSpace/issues/66