### PR TITLE
Remove Simulation Tab

### DIFF
--- a/explore/templates/explore/index.html
+++ b/explore/templates/explore/index.html
@@ -139,9 +139,6 @@
                 <a class="dropdown-item text-white display-4" href="" aria-expanded="false">BioInformatics</a>
               </div>
             </li>
-            <li class="nav-item">
-              <a class="nav-link link text-white display-4" href="" aria-expanded="false"><span class="mbri-edit mbr-iconfont mbr-iconfont-btn"></span>Simulation</a>
-            </li>
 
             <li class="nav-item">
               <a class="nav-link link text-white display-4" href="{% url 'leaderboard:index' %}" aria-expanded="false"><span class="mbri-rocket mbr-iconfont mbr-iconfont-btn"></span>Leaderboard</a>
@@ -204,9 +201,6 @@
                   <a class="dropdown-item text-white display-4" href="{% url 'practice:subdomain' track='data_structures' subdomain='advanced' %}" aria-expanded="false">Data-Structures</a>
                   <a class="dropdown-item text-white display-4" href="" aria-expanded="false">BioInformatics</a>
                 </div>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link link text-white display-4" href="" aria-expanded="false"><span class="mbri-edit mbr-iconfont mbr-iconfont-btn"></span>Simulation</a>
               </li>
 
               <li class="nav-item">

--- a/home/templates/home/index.html
+++ b/home/templates/home/index.html
@@ -75,9 +75,6 @@
                 <a class="dropdown-item text-white display-4" href="" aria-expanded="false">BioInformatics</a>
               </div>
             </li>
-            <li class="nav-item">
-              <a class="nav-link link text-white display-4" href="" aria-expanded="false"><span class="mbri-edit mbr-iconfont mbr-iconfont-btn"></span>Simulation</a>
-            </li>
 
             <li class="nav-item">
               <a class="nav-link link text-white display-4" href="{% url 'leaderboard:index' %}" aria-expanded="false"><span class="mbri-rocket mbr-iconfont mbr-iconfont-btn"></span>Leaderboard</a>
@@ -140,9 +137,6 @@
                   <a class="dropdown-item text-white display-4" href="{% url 'practice:subdomain' track='data_structures' subdomain='advanced' %}" aria-expanded="false">Data-Structures</a>
                   <a class="dropdown-item text-white display-4" href="" aria-expanded="false">BioInformatics</a>
                 </div>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link link text-white display-4" href="" aria-expanded="false"><span class="mbri-edit mbr-iconfont mbr-iconfont-btn"></span>Simulation</a>
               </li>
 
               <li class="nav-item">

--- a/leaderboard/templates/leaderboard/index.html
+++ b/leaderboard/templates/leaderboard/index.html
@@ -94,10 +94,6 @@
                         <a class="dropdown-item text-white display-4" href="{% url 'practice:subdomain' track='data_structures' subdomain='advanced' %}" aria-expanded="false">Data-Structures</a>
                         <a class="dropdown-item text-white display-4" href="" aria-expanded="false">BioInformatics</a>
                       </div>
-              </li>
-                <li class="nav-item">
-                <a class="nav-link link text-white display-4" href="" aria-expanded="false"><span class="mbri-edit mbr-iconfont mbr-iconfont-btn"></span>Simulation</a>
-              </li>
 
               <li class="nav-item">
                 <a class="nav-link link text-white display-4" href="{% url 'leaderboard:index' %}" aria-expanded="false"><span class="mbri-rocket mbr-iconfont mbr-iconfont-btn"></span>Leaderboard</a>
@@ -160,9 +156,6 @@
                 <a class="dropdown-item text-white display-4" href="{% url 'practice:subdomain' track='data_structures' subdomain='advanced' %}" aria-expanded="false">Data-Structures</a>
                 <a class="dropdown-item text-white display-4" href="" aria-expanded="false">BioInformatics</a>
               </div>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link link text-white display-4" href="" aria-expanded="false"><span class="mbri-edit mbr-iconfont mbr-iconfont-btn"></span>Simulation</a>
             </li>
 
             <li class="nav-item">

--- a/practice/templates/practice/question.html
+++ b/practice/templates/practice/question.html
@@ -182,9 +182,6 @@
                 <a class="dropdown-item text-white display-4" href="" aria-expanded="false">BioInformatics</a>
               </div>
             </li>
-            <li class="nav-item">
-              <a class="nav-link link text-white display-4" href="" aria-expanded="false"><span class="mbri-edit mbr-iconfont mbr-iconfont-btn"></span>Simulation</a>
-            </li>
 
             <li class="nav-item">
               <a class="nav-link link text-white display-4" href="{% url 'leaderboard:index' %}" aria-expanded="false"><span class="mbri-rocket mbr-iconfont mbr-iconfont-btn"></span>Leaderboard</a>
@@ -247,9 +244,6 @@
                   <a class="dropdown-item text-white display-4" href="{% url 'practice:subdomain' track='data_structures' subdomain='advanced' %}" aria-expanded="false">Data-Structures</a>
                   <a class="dropdown-item text-white display-4" href="" aria-expanded="false">BioInformatics</a>
                 </div>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link link text-white display-4" href="" aria-expanded="false"><span class="mbri-edit mbr-iconfont mbr-iconfont-btn"></span>Simulation</a>
               </li>
 
               <li class="nav-item">

--- a/practice/templates/practice/subdomain.html
+++ b/practice/templates/practice/subdomain.html
@@ -169,9 +169,6 @@
                 <a class="dropdown-item text-white display-4" href="" aria-expanded="false">BioInformatics</a>
               </div>
             </li>
-            <li class="nav-item">
-              <a class="nav-link link text-white display-4" href="" aria-expanded="false"><span class="mbri-edit mbr-iconfont mbr-iconfont-btn"></span>Simulation</a>
-            </li>
 
             <li class="nav-item">
               <a class="nav-link link text-white display-4" href="{% url 'leaderboard:index' %}" aria-expanded="false"><span class="mbri-rocket mbr-iconfont mbr-iconfont-btn"></span>Leaderboard</a>
@@ -234,9 +231,6 @@
                   <a class="dropdown-item text-white display-4" href="{% url 'practice:subdomain' track='data_structures' subdomain='advanced' %}" aria-expanded="false">Data-Structures</a>
                   <a class="dropdown-item text-white display-4" href="" aria-expanded="false">BioInformatics</a>
                 </div>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link link text-white display-4" href="" aria-expanded="false"><span class="mbri-edit mbr-iconfont mbr-iconfont-btn"></span>Simulation</a>
               </li>
 
               <li class="nav-item">


### PR DESCRIPTION
Simulation Tab is currently not ready so temporarily removing it
from the navbar. Once we are done with Practice section, we can
start working on it.

Fixes https://github.com/Utkarsh1308/TabOverSpace/issues/68